### PR TITLE
Added support to send tx using ledger wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
         "typedoc": "^0.25.13",
         "typescript": "^5.3.3",
         "webpack": "^5.89.0"
+      },
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/@aptos-labs/aptos-client": {
@@ -45,63 +48,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@ethersproject/bytes": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/keccak256": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "node_modules/@ethersproject/keccak256/node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
-    "node_modules/@ethersproject/logger": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ]
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "supra-l1-sdk",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "supra-l1-sdk",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
-        "@ethersproject/keccak256": "^5.7.0",
         "aptos": "^1.21.0",
         "js-sha3": "^0.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supra-l1-sdk",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Typescript SDK for Supra",
   "exports": {
     "browser": {

--- a/package.json
+++ b/package.json
@@ -2,30 +2,24 @@
   "name": "supra-l1-sdk",
   "version": "4.0.0",
   "description": "Typescript SDK for Supra",
+  "engines": {
+    "node": ">=11.0.0"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
-    "browser": {
-      "import": "./dist/browser/index.mjs",
-      "require": "./dist/browser/index.js",
-      "types": "./dist/browser/index.d.ts"
-    },
-    "node": {
-      "import": "./dist/node/index.mjs",
-      "require": "./dist/node/index.js",
-      "types": "./dist/node/index.d.ts"
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
-  "browser": {
-    "./dist/node/index.mjs": "./dist/browser/index.mjs",
-    "./dist/node/index.js": "./dist/browser/index.js"
-  },
-  "main": "./dist/node/index.js",
-  "module": "./dist/node/index.mjs",
-  "types": "./dist/node/index.d.ts",
-  "files": [
-    "./dist/"
-  ],
   "scripts": {
-    "build": "rm -rf dist && tsup --platform node --format cjs,esm --dts --out-dir dist/node && tsup --platform browser --format cjs,esm --dts  --minify --out-dir dist/browser",
+    "build": "npm run build:clean && npm run _build:node && npm run _build:browser",
+    "build:clean": "rm -rf dist",
+    "_build:browser": "tsup --platform browser --format iife --global-name supraSDK --minify",
+    "_build:node": "tsup --platform node --format cjs,esm --dts",
     "prepare": "npm run build",
     "docs": "npx typedoc",
     "test": "ts-node ./src/example.ts"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "./dist/"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsup --platform node --format cjs,esm --dts --out-dir dist/node && tsup --platform browser --format cjs,esm --dts  --minify --out-dir dist/browser",
+    "build": "rm -rf dist && tsup --platform node --out-dir dist/node && tsup --platform browser --out-dir dist/browser",
     "prepare": "npm run build",
     "docs": "npx typedoc",
     "test": "ts-node ./src/example.ts"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@ethersproject/keccak256": "^5.7.0",
     "aptos": "^1.21.0",
     "js-sha3": "^0.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -2,24 +2,30 @@
   "name": "supra-l1-sdk",
   "version": "4.0.0",
   "description": "Typescript SDK for Supra",
-  "engines": {
-    "node": ">=11.0.0"
-  },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+    "browser": {
+      "import": "./dist/browser/index.mjs",
+      "require": "./dist/browser/index.js",
+      "types": "./dist/browser/index.d.ts"
+    },
+    "node": {
+      "import": "./dist/node/index.mjs",
+      "require": "./dist/node/index.js",
+      "types": "./dist/node/index.d.ts"
     }
   },
+  "browser": {
+    "./dist/node/index.mjs": "./dist/browser/index.mjs",
+    "./dist/node/index.js": "./dist/browser/index.js"
+  },
+  "main": "./dist/node/index.js",
+  "module": "./dist/node/index.mjs",
+  "types": "./dist/node/index.d.ts",
+  "files": [
+    "./dist/"
+  ],
   "scripts": {
-    "build": "npm run build:clean && npm run _build:node && npm run _build:browser",
-    "build:clean": "rm -rf dist",
-    "_build:browser": "tsup --platform browser --format iife --global-name supraSDK --minify",
-    "_build:node": "tsup --platform node --format cjs,esm --dts",
+    "build": "rm -rf dist && tsup --platform node --format cjs,esm --dts --out-dir dist/node && tsup --platform browser --format cjs,esm --dts  --minify --out-dir dist/browser",
     "prepare": "npm run build",
     "docs": "npx typedoc",
     "test": "ts-node ./src/example.ts"

--- a/src/example.ts
+++ b/src/example.ts
@@ -171,7 +171,6 @@ import {
   // To simulate transaction using serialized raw transaction data
   console.log(
     await supraClient.simulateTxUsingSerializedRawTransaction(
-      senderAccount.address(),
       {
         Ed25519: {
           public_key: senderAccount.pubKey().toString(),
@@ -289,7 +288,6 @@ import {
   // Sending sponsor transaction
   console.log(
     await supraClient.sendSponsorTransaction(
-      senderAccount.address().toString(),
       feePayerAccount.address().toString(),
       [],
       sponsorTxSupraCoinTransferRawTransaction,
@@ -359,7 +357,6 @@ import {
   // Sending Multi-Agent transaction
   console.log(
     await supraClient.sendMultiAgentTransaction(
-      senderAccount.address().toString(),
       [secondarySigner1.address().toString()],
       multiAgentRawTransaction,
       multiAgentSenderAuthenticator,
@@ -370,4 +367,38 @@ import {
       }
     )
   );
+
+  let ledgerWalletSenderAccountPubkey = new TxnBuilderTypes.Ed25519PublicKey(
+    Buffer.from(
+      "c127c6b1955dd5cb815cd44372aac92811430fa805e473935cd3a147c90b4cee",
+      "hex"
+    )
+  );
+  let signature = new HexString(
+    "82000c4f40aa4cbd35b26b4b56ea073e9a33cfd32040eab0834577bf7451808eaa79a304f5cf99a1e5ea9660f190fef69de8f200e432c612a7e895e5528c770e"
+  );
+  let serializedRawTransaction = Buffer.from(
+    "4451aa86090708900650da5fdb8d7530f1d90dee338448c0223e728378f182c1030000000000000002000000000000000000000000000000000000000000000000000000000000000104636f696e087472616e73666572010700000000000000000000000000000000000000000000000000000000000000010a73757072615f636f696e095375707261436f696e000220b8922417130785087f9c7926e76542531b703693fdc74c9386b65cf4427f4e8008e80300000000000020a10700000000006400000000000000919f56670000000006",
+    "hex"
+  );
+
+  try {
+    // As we had created this tx payload during testing,
+    // hence its expected to be failed with 'TRANSACTION_EXPIRED'
+    await supraClient.sendTxUsingSerializedRawTransactionAndSignature(
+      HexString.fromUint8Array(ledgerWalletSenderAccountPubkey.toBytes()),
+      signature,
+      serializedRawTransaction,
+      {
+        enableTransactionSimulation: true,
+        enableWaitForTransaction: true,
+      }
+    );
+  } catch (err) {
+    if (!(err as Error).message.includes("TRANSACTION_EXPIRED")) {
+      throw new Error(
+        "Something went wrong tx must fail with 'TRANSACTION_EXPIRED'"
+      );
+    }
+  }
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,7 @@ import {
   RAW_TRANSACTION_SALT,
   RAW_TRANSACTION_WITH_DATA_SALT,
 } from "./constants";
-import { sha3_256 } from "js-sha3";
-import { keccak256 } from "@ethersproject/keccak256";
+import sha3 from "js-sha3";
 
 export * from "./types";
 export * from "./constants";
@@ -832,7 +831,7 @@ export class SupraClient {
   ): Uint8Array {
     let preHash = Uint8Array.from(
       Buffer.from(
-        sha3_256(
+        sha3.sha3_256(
           rawTxn instanceof TxnBuilderTypes.RawTransaction
             ? RAW_TRANSACTION_SALT
             : RAW_TRANSACTION_WITH_DATA_SALT
@@ -1248,7 +1247,7 @@ export class SupraClient {
   static deriveTransactionHash(
     signedTransaction: TxnBuilderTypes.SignedTransaction
   ): string {
-    return keccak256(BCS.bcsToBytes(signedTransaction));
+    return sha3.keccak256(BCS.bcsToBytes(signedTransaction));
   }
 
   /**

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -2,9 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
-  dts: true,
   splitting: false,
   sourcemap: true,
-  target: "es2018",
+  target: "es2020",
 });

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  minify: true,
   splitting: false,
   sourcemap: true,
   target: "es2020",


### PR DESCRIPTION
This PR adds a feature to send `tx` using a ledger wallet.
- As ledger wallet does not support sending a tx and it only supports signing message, hence in this PR we have added `sendTxUsingSerializedRawTransactionAndSignature` which expects `serializedRawTransaction` and a signature obtained from ledger wallet.
- There is also a breaking change, `sendSponsorTransaction`, `sendMultiAgentTransaction` and `simulateTxUsingSerializedRawTransaction` does not expects `senderAccountAddress`

Usage guidelines for Starkey wallet team,
- Starkey Wallet can interact with the Supra ledger wallet app as they interact with the Aptos ledger wallet app.
- Signature for tx can be obtained from the Supra ledger wallet app same as the Aptos ledger wallet app.
- Leder wallet expects `signature_message` to generate a signature so for that `getSupraTransactionSignatureMessage` can be used to get `signature_message`
- Once the signature is obtained from the ledger wallet, call `sendTxUsingSerializedRawTransactionAndSignature` to send tx.
