### PR TITLE
Considered nested type args in parseFunctionTypeArgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supra-l1-sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Typescript SDK for Supra",
   "exports": {
     "browser": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export const parseFunctionTypeArgs = (
         address: structTagData.address.toHexString().toString(),
         module: structTagData.module_name.value,
         name: structTagData.name.value,
-        type_args: [],
+        type_args: parseFunctionTypeArgs(structTagData.type_args),
       },
     });
   });


### PR DESCRIPTION
In SDK, we have `parseFunctionTypeArgs` utility function which converts `TypeArgs` into `JSON` format, this is a legacy utility function and at the time of creating that we had not considered that type arg can also be nested.